### PR TITLE
Add retry interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.0
+
+ - Add `interval` option for `retries` which allows to execute a retry after a given period of time. I.e. `interval: 50ms`
+
 # v1.1.0
 
  - Add `not-contains` assertion on `stdout` and `stderr`

--- a/commander_unix.yaml
+++ b/commander_unix.yaml
@@ -52,5 +52,7 @@ tests:
     stdout:
       contains:
         - ✗ echo hello, retries 3
-        - ✓ ./integration/unix/_fixtures/retries.sh, retries 2
+        - ✓ it should retry failed commands, retries 2
+        - ✗ it should retry failed commands with an interval, retries 2
+        - "Duration: 0.1" # Assertion that the interval is working
     exit-code: 1

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -68,5 +68,6 @@ tests:
                 ANOTHER: yeah # Add another env variable
             timeout: 1000 # Overwrite timeout
             retries: 5
+            interval: 30ms
         exit-code: 0
 ```

--- a/integration/unix/retries.yaml
+++ b/integration/unix/retries.yaml
@@ -4,7 +4,16 @@ tests:
     config:
       retries: 3
 
-  ./integration/unix/_fixtures/retries.sh:
+  it should retry failed commands:
+    command: ./integration/unix/_fixtures/retries.sh
     exit-code: 0
     config:
+      retries: 2
+
+  it should retry failed commands with an interval:
+    command: echo hello
+    stdout: fail
+    exit-code: 0
+    config:
+      interval: 50ms
       retries: 2

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -125,13 +125,7 @@ func Start(tests []TestCase, maxConcurrent int) <-chan TestResult {
 						break
 					}
 
-					if t.Command.GetRetries() > 1 && t.Command.Interval != "" {
-						interval, err := time.ParseDuration(t.Command.Interval)
-						if err != nil {
-							panic(fmt.Sprintf("'%s' interval error: %s", t.Command.Cmd, err))
-						}
-						time.Sleep(interval)
-					}
+					executeRetryInterval(t)
 				}
 
 				out <- result
@@ -145,6 +139,16 @@ func Start(tests []TestCase, maxConcurrent int) <-chan TestResult {
 	}(out)
 
 	return out
+}
+
+func executeRetryInterval(t TestCase) {
+	if t.Command.GetRetries() > 1 && t.Command.Interval != "" {
+		interval, err := time.ParseDuration(t.Command.Interval)
+		if err != nil {
+			panic(fmt.Sprintf("'%s' interval error: %s", t.Command.Cmd, err))
+		}
+		time.Sleep(interval)
+	}
 }
 
 // runTest executes the current test case

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -36,10 +36,11 @@ type TestCase struct {
 
 //TestConfig represents the configuration for a test
 type TestConfig struct {
-	Env     map[string]string
-	Dir     string
-	Timeout string
-	Retries int
+	Env      map[string]string
+	Dir      string
+	Timeout  string
+	Retries  int
+	Interval string
 }
 
 // ResultStatus represents the status code of a test result
@@ -74,11 +75,12 @@ type ExpectedOut struct {
 
 // CommandUnderTest represents the command under test
 type CommandUnderTest struct {
-	Cmd     string
-	Env     map[string]string
-	Dir     string
-	Timeout string
-	Retries int
+	Cmd      string
+	Env      map[string]string
+	Dir      string
+	Timeout  string
+	Retries  int
+	Interval string
 }
 
 // TestResult represents the TestCase and the ValidationResult

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,11 +1,13 @@
 package runtime
 
 import (
+	"fmt"
 	"github.com/SimonBaeumer/commander/pkg/cmd"
 	"log"
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Constants for defining the various tested properties
@@ -121,6 +123,14 @@ func Start(tests []TestCase, maxConcurrent int) <-chan TestResult {
 					result.Tries = i
 					if result.ValidationResult.Success {
 						break
+					}
+
+					if t.Command.GetRetries() > 1 && t.Command.Interval != "" {
+						interval, err := time.ParseDuration(t.Command.Interval)
+						if err != nil {
+							panic(fmt.Sprintf("'%s' interval error: %s", t.Command.Cmd, err))
+						}
+						time.Sleep(interval)
 					}
 				}
 

--- a/pkg/suite/yaml_suite.go
+++ b/pkg/suite/yaml_suite.go
@@ -15,10 +15,11 @@ type YAMLConfig struct {
 
 // YAMLTestConfig is a struct to represent the test config
 type YAMLTestConfig struct {
-	Env     map[string]string `yaml:"env,omitempty"`
-	Dir     string            `yaml:"dir,omitempty"`
-	Timeout string            `yaml:"timeout,omitempty"`
-	Retries int               `yaml:"retries,omitempty"`
+	Env      map[string]string `yaml:"env,omitempty"`
+	Dir      string            `yaml:"dir,omitempty"`
+	Timeout  string            `yaml:"timeout,omitempty"`
+	Retries  int               `yaml:"retries,omitempty"`
+	Interval string            `yaml:"interval,omitempty"`
 }
 
 // YAMLTest represents a test in the yaml test suite
@@ -69,10 +70,11 @@ func ParseYAML(content []byte) Suite {
 	return YAMLSuite{
 		TestCases: convertYAMLConfToTestCases(yamlConfig),
 		Config: runtime.TestConfig{
-			Env:     yamlConfig.Config.Env,
-			Dir:     yamlConfig.Config.Dir,
-			Timeout: yamlConfig.Config.Timeout,
-			Retries: yamlConfig.Config.Retries,
+			Env:      yamlConfig.Config.Env,
+			Dir:      yamlConfig.Config.Dir,
+			Timeout:  yamlConfig.Config.Timeout,
+			Retries:  yamlConfig.Config.Retries,
+			Interval: yamlConfig.Config.Interval,
 		},
 	}
 }
@@ -84,11 +86,12 @@ func convertYAMLConfToTestCases(conf YAMLConfig) []runtime.TestCase {
 		tests = append(tests, runtime.TestCase{
 			Title: t.Title,
 			Command: runtime.CommandUnderTest{
-				Cmd:     t.Command,
-				Env:     t.Config.Env,
-				Dir:     t.Config.Dir,
-				Timeout: t.Config.Timeout,
-				Retries: t.Config.Retries,
+				Cmd:      t.Command,
+				Env:      t.Config.Env,
+				Dir:      t.Config.Dir,
+				Timeout:  t.Config.Timeout,
+				Retries:  t.Config.Retries,
+				Interval: t.Config.Interval,
 			},
 			Expected: runtime.Expected{
 				ExitCode: t.ExitCode,
@@ -140,10 +143,11 @@ func (y *YAMLConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	//Parse global configuration
 	y.Config = YAMLTestConfig{
-		Env:     params.Config.Env,
-		Dir:     params.Config.Dir,
-		Timeout: params.Config.Timeout,
-		Retries: params.Config.Retries,
+		Env:      params.Config.Env,
+		Dir:      params.Config.Dir,
+		Timeout:  params.Config.Timeout,
+		Retries:  params.Config.Retries,
+		Interval: params.Config.Interval,
 	}
 
 	return nil
@@ -237,6 +241,10 @@ func (y *YAMLConfig) mergeConfigs(local YAMLTestConfig, global YAMLTestConfig) Y
 
 	if local.Retries != 0 {
 		conf.Retries = local.Retries
+	}
+
+	if local.Interval != "" {
+		conf.Interval = local.Interval
 	}
 
 	return conf

--- a/pkg/suite/yaml_suite_test.go
+++ b/pkg/suite/yaml_suite_test.go
@@ -184,6 +184,7 @@ config:
     dir: /home/commander/
     timeout: 10ms
     retries: 2
+    interval: 500ms
 
 tests:
     echo hello:
@@ -194,6 +195,7 @@ tests:
            dir: /home/test
            timeout: 1s
            retries: 10
+           interval: 5s
 `)
 
 	got := ParseYAML(yaml)
@@ -201,11 +203,13 @@ tests:
 	assert.Equal(t, "/home/commander/", got.GetGlobalConfig().Dir)
 	assert.Equal(t, "10ms", got.GetGlobalConfig().Timeout)
 	assert.Equal(t, 2, got.GetGlobalConfig().Retries)
+	assert.Equal(t, "500ms", got.GetGlobalConfig().Interval)
 
 	assert.Equal(t, map[string]string{"KEY": "local", "ANOTHER_KEY": "another_global"}, got.GetTests()[0].Command.Env)
 	assert.Equal(t, "/home/test", got.GetTests()[0].Command.Dir)
 	assert.Equal(t, "1s", got.GetTests()[0].Command.Timeout)
 	assert.Equal(t, 10, got.GetTests()[0].Command.Retries)
+	assert.Equal(t, "5s", got.GetTests()[0].Command.Interval)
 }
 
 func TestYAMLSuite_ShouldThrowAnErrorIfFieldIsNotRegistered(t *testing.T) {


### PR DESCRIPTION
It is now possible to define intervals between retry attempts.

```yaml
config:
  retries: 2
  interval: 50ms
```