### PR TITLE
Read environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.2.0
 
- - Add `interval` option for `retries` which allows to execute a retry after a given period of time. I.e. `interval: 50ms`
+- Add reading envrionment variables from shell
+- Add `interval` option for `retries` which allows to execute a retry after a given period of time. I.e. `interval: 50ms`
 
 # v1.1.0
 

--- a/cmd/commander/commander.go
+++ b/cmd/commander/commander.go
@@ -37,26 +37,7 @@ func createCliApp() *cli.App {
 
 	cliapp.Commands = []cli.Command{
 		createTestCommand(),
-		{
-			Name:      "add",
-			Usage:     "Automatically add a test to your test suite",
-			ArgsUsage: "[command]",
-			Flags: []cli.Flag{
-				cli.BoolFlag{
-					Name:  "stdout",
-					Usage: "Output test file to stdout",
-				},
-				cli.BoolFlag{
-					Name:  "no-file",
-					Usage: "Don't create a commander.yaml",
-				},
-				cli.StringFlag{
-					Name:  "file",
-					Usage: "Write to another file, default is commander.yaml",
-				},
-			},
-			Action: addCommand,
-		},
+		createAddCommand(),
 	}
 	return cliapp
 }
@@ -89,35 +70,56 @@ func createTestCommand() cli.Command {
 	}
 }
 
-func addCommand(c *cli.Context) error {
-	file := ""
-	var existedContent []byte
+func createAddCommand() cli.Command {
+	return cli.Command{
+		Name:      "add",
+		Usage:     "Automatically add a test to your test suite",
+		ArgsUsage: "[command]",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "stdout",
+				Usage: "Output test file to stdout",
+			},
+			cli.BoolFlag{
+				Name:  "no-file",
+				Usage: "Don't create a commander.yaml",
+			},
+			cli.StringFlag{
+				Name:  "file",
+				Usage: "Write to another file, default is commander.yaml",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			file := ""
+			var existedContent []byte
 
-	if !c.Bool("no-file") {
-		dir, _ := os.Getwd()
-		file = path.Join(dir, app.CommanderFile)
-		if c.String("file") != "" {
-			file = c.String("file")
-		}
-		existedContent, _ = ioutil.ReadFile(file)
+			if !c.Bool("no-file") {
+				dir, _ := os.Getwd()
+				file = path.Join(dir, app.CommanderFile)
+				if c.String("file") != "" {
+					file = c.String("file")
+				}
+				existedContent, _ = ioutil.ReadFile(file)
+			}
+
+			content, err := app.AddCommand(strings.Join(c.Args(), " "), existedContent)
+
+			if err != nil {
+				return err
+			}
+
+			if c.Bool("stdout") {
+				fmt.Println(string(content))
+			}
+			if !c.Bool("no-file") {
+				fmt.Println("written to", file)
+				err := ioutil.WriteFile(file, content, 0755)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
 	}
-
-	content, err := app.AddCommand(strings.Join(c.Args(), " "), existedContent)
-
-	if err != nil {
-		return err
-	}
-
-	if c.Bool("stdout") {
-		fmt.Println(string(content))
-	}
-	if !c.Bool("no-file") {
-		fmt.Println("written to", file)
-		err := ioutil.WriteFile(file, content, 0755)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/cmd/commander/commander.go
+++ b/cmd/commander/commander.go
@@ -36,7 +36,7 @@ func createCliApp() *cli.App {
 	cliapp.Version = version
 
 	cliapp.Commands = []cli.Command{
-		createAddCommand(),
+		createTestCommand(),
 		{
 			Name:      "add",
 			Usage:     "Automatically add a test to your test suite",
@@ -61,7 +61,7 @@ func createCliApp() *cli.App {
 	return cliapp
 }
 
-func createAddCommand() cli.Command {
+func createTestCommand() cli.Command {
 	return cli.Command{
 		Name:      "test",
 		Usage:     "Execute the test suite",

--- a/commander_unix.yaml
+++ b/commander_unix.yaml
@@ -32,10 +32,14 @@ tests:
 
   test global and local configurations:
     command: ./commander test ./integration/unix/config_test.yaml
+    config:
+      env:
+        COMMANDER_FROM_SHELL: from_shell
     stdout:
       contains:
         - ✓ should print global env value
         - ✓ should print local env value
+        - ✓ should print env var from shell
     exit-code: 0
 
   test add command:

--- a/commander_windows.yaml
+++ b/commander_windows.yaml
@@ -36,6 +36,9 @@ tests:
 
   test global and local configurations:
     command: commander.exe test ./integration/windows/config_test.yaml
+    config:
+      env:
+        COMMANDER_FROM_SHELL: from_shell
     stdout:
       contains:
         - should print global

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -33,6 +33,7 @@ config: # Config for all tests
     dir: /tmp #Set working directory
     env: # Environment variables
         KEY: global
+        PATH_FROM_SHELL: ${PATH} # Read an env variable from the current shell
     timeout: 5000 # Timeout in ms
     retries: 2 # Define retries for each test
     

--- a/integration/unix/config_test.yaml
+++ b/integration/unix/config_test.yaml
@@ -2,6 +2,7 @@ config:
   env:
     KEY: value
     ANOTHER: global
+    COMMANDER_FROM_SHELL: ${COMMANDER_FROM_SHELL}
 tests:
   should print global env value:
     command: echo $KEY
@@ -27,4 +28,9 @@ tests:
     command: echo hello
     config:
       timeout: 100ms
+    exit-code: 0
+
+  should print env var from shell:
+    command: echo read ${COMMANDER_FROM_SHELL} $KEY
+    stdout: read from_shell value
     exit-code: 0

--- a/integration/windows/config_test.yaml
+++ b/integration/windows/config_test.yaml
@@ -2,6 +2,7 @@ config:
   env:
     KEY: value
     ANOTHER: global
+    COMMANDER_FROM_SHELL: ${COMMANDER_FROM_SHELL}
 tests:
   should print global env value:
     command: echo %KEY%

--- a/integration/windows/shell_env.yaml
+++ b/integration/windows/shell_env.yaml
@@ -1,0 +1,3 @@
+tests:
+  it should read from shell env:
+    env:

--- a/pkg/cmd/command.go
+++ b/pkg/cmd/command.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -31,8 +33,23 @@ func NewCommand(cmd string) *Command {
 }
 
 // AddEnv adds an environment variable to the command
+// If a variable gets passed like ${VAR_NAME} the env variable will be read out by the current shell
 func (c *Command) AddEnv(key string, value string) {
+	if isEnvFromShell(value) {
+		value = os.Getenv("COMMANDER_TEST_SOME_KEY")
+	}
 	c.Env = append(c.Env, fmt.Sprintf("%s=%s", key, value))
+}
+
+func isEnvFromShell(val string) bool {
+	r := strings.Index(val, "${")
+	if r != 0 {
+		return false
+	}
+	if strings.Index(val, "}") != (len(val) - 1) {
+		return false
+	}
+	return true
 }
 
 //SetTimeoutMS sets the timeout in milliseconds

--- a/pkg/cmd/command.go
+++ b/pkg/cmd/command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -35,21 +36,25 @@ func NewCommand(cmd string) *Command {
 // AddEnv adds an environment variable to the command
 // If a variable gets passed like ${VAR_NAME} the env variable will be read out by the current shell
 func (c *Command) AddEnv(key string, value string) {
-	if isEnvFromShell(value) {
-		value = os.Getenv("COMMANDER_TEST_SOME_KEY")
+	vars := parseEnvVariableFromShell(value)
+	for _, v := range vars {
+		value = strings.Replace(value, v, os.Getenv(removeEnvVarSyntax(v)), -1)
 	}
+
 	c.Env = append(c.Env, fmt.Sprintf("%s=%s", key, value))
 }
 
-func isEnvFromShell(val string) bool {
-	r := strings.Index(val, "${")
-	if r != 0 {
-		return false
-	}
-	if strings.Index(val, "}") != (len(val) - 1) {
-		return false
-	}
-	return true
+// Removes the ${...} characters
+func removeEnvVarSyntax(v string) string {
+	return v[2:(len(v) - 1)]
+}
+
+//Read all environment variables from the given value
+//with the syntax ${VAR_NAME}
+func parseEnvVariableFromShell(val string) []string {
+	reg := regexp.MustCompile(`\$\{.*?\}`)
+	matches := reg.FindAllString(val, -1)
+	return matches
 }
 
 //SetTimeoutMS sets the timeout in milliseconds

--- a/pkg/cmd/command_test.go
+++ b/pkg/cmd/command_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -62,6 +63,20 @@ func TestCommand_AddEnv(t *testing.T) {
 	c := NewCommand("echo test")
 	c.AddEnv("key", "value")
 	assert.Equal(t, []string{"key=value"}, c.Env)
+}
+
+func TestCommand_AddEnvWithShellVariable(t *testing.T) {
+	const TestEnvKey = "COMMANDER_TEST_SOME_KEY"
+	os.Setenv(TestEnvKey, "test from shell")
+	defer os.Unsetenv(TestEnvKey)
+
+	c := NewCommand("echo $SOME_KEY")
+	c.AddEnv("SOME_KEY", fmt.Sprintf("${%s}", TestEnvKey))
+
+	err := c.Execute()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "test from shell", c.Stdout())
 }
 
 func TestCommand_SetTimeoutMS_DefaultTimeout(t *testing.T) {

--- a/pkg/cmd/command_test.go
+++ b/pkg/cmd/command_test.go
@@ -70,7 +70,7 @@ func TestCommand_AddEnvWithShellVariable(t *testing.T) {
 	os.Setenv(TestEnvKey, "test from shell")
 	defer os.Unsetenv(TestEnvKey)
 
-	c := NewCommand("echo $SOME_KEY")
+	c := NewCommand(getCommand())
 	c.AddEnv("SOME_KEY", fmt.Sprintf("${%s}", TestEnvKey))
 
 	err := c.Execute()
@@ -89,7 +89,7 @@ func TestCommand_AddMultipleEnvWithShellVariable(t *testing.T) {
 		os.Unsetenv(TestEnvKeyName)
 	}()
 
-	c := NewCommand("echo $SOME_KEY")
+	c := NewCommand(getCommand())
 	envValue := fmt.Sprintf("Hello ${%s}, I am ${%s}", TestEnvKeyPlanet, TestEnvKeyName)
 	c.AddEnv("SOME_KEY", envValue)
 
@@ -97,6 +97,14 @@ func TestCommand_AddMultipleEnvWithShellVariable(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "Hello world, I am Simon", c.Stdout())
+}
+
+func getCommand() string {
+	command := "echo $SOME_KEY"
+	if runtime.GOOS == "windows" {
+		command = "echo %SOME_KEY%"
+	}
+	return command
 }
 
 func TestCommand_SetTimeoutMS_DefaultTimeout(t *testing.T) {

--- a/pkg/cmd/command_test.go
+++ b/pkg/cmd/command_test.go
@@ -79,6 +79,26 @@ func TestCommand_AddEnvWithShellVariable(t *testing.T) {
 	assert.Equal(t, "test from shell", c.Stdout())
 }
 
+func TestCommand_AddMultipleEnvWithShellVariable(t *testing.T) {
+	const TestEnvKeyPlanet = "COMMANDER_TEST_PLANET"
+	const TestEnvKeyName = "COMMANDER_TEST_NAME"
+	os.Setenv(TestEnvKeyPlanet, "world")
+	os.Setenv(TestEnvKeyName, "Simon")
+	defer func() {
+		os.Unsetenv(TestEnvKeyPlanet)
+		os.Unsetenv(TestEnvKeyName)
+	}()
+
+	c := NewCommand("echo $SOME_KEY")
+	envValue := fmt.Sprintf("Hello ${%s}, I am ${%s}", TestEnvKeyPlanet, TestEnvKeyName)
+	c.AddEnv("SOME_KEY", envValue)
+
+	err := c.Execute()
+
+	assert.Nil(t, err)
+	assert.Equal(t, "Hello world, I am Simon", c.Stdout())
+}
+
 func TestCommand_SetTimeoutMS_DefaultTimeout(t *testing.T) {
 	c := NewCommand("echo test")
 	c.SetTimeoutMS(0)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -18,6 +18,8 @@ const (
 	LineCount = "LineCount"
 )
 
+const WorkerCountMultiplicator = 5
+
 // Result status codes
 const (
 	//Success status
@@ -108,7 +110,7 @@ func Start(tests []TestCase, maxConcurrent int) <-chan TestResult {
 
 	workerCount := maxConcurrent
 	if maxConcurrent == 0 {
-		workerCount = runtime.NumCPU() * 5
+		workerCount = runtime.NumCPU() * WorkerCountMultiplicator
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Fixes #80

It is now possible to read environment variables from the current shell.

```yaml
config:
  env:
    PATH_FROM_SHELL: ${PATH}
```

## Checklist

 - [x] Added unit / integration tests for windows, macOS and Linux? 
 - [x] Added a changelog entry in [CHANGELOG.md](../CHANGELOG.md)?
 - [x] Updated the documentation ([README.md](../README.md), [docs](../docs))?
 - [x] Does your change work on `Linux`, `Windows` and `macOS`?