### PR TITLE
Fix add command for existing stdout and stderr properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp.yml
 coverage
 *.exe
 commander.yaml
+tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+# v1.2.1
+
+ - Fix `add` command if `stdout` or `stderr` properties were removed if a new test was added
+
 # v1.2.0
 
-- Add reading envrionment variables from shell
-- Add `interval` option for `retries` which allows to execute a retry after a given period of time. I.e. `interval: 50ms`
+ - Add reading environment variables from shell, i.e. `${PATH}`
+ - Add `interval` option for `retries` which allows to execute a retry after a given period of time. I.e. `interval: 50ms`
 
 # v1.1.0
 

--- a/pkg/app/add_command.go
+++ b/pkg/app/add_command.go
@@ -61,13 +61,6 @@ func AddCommand(command string, existed []byte) ([]byte, error) {
 	return out, nil
 }
 
-func stringOrNil(str string) interface{} {
-	if str == "" {
-		return nil
-	}
-	return str
-}
-
 func convertConfig(config suite.YAMLTestConfig) suite.YAMLTestConfig {
 	if config.Dir == "" && len(config.Env) == 0 && config.Timeout == "" {
 		return suite.YAMLTestConfig{}

--- a/pkg/app/add_command_test.go
+++ b/pkg/app/add_command_test.go
@@ -25,7 +25,7 @@ tests:
 	assert.Equal(t, "tests:\n  echo exists:\n    exit-code: 0\n  echo hello:\n    exit-code: 0\n    stdout: hello\n", string(content))
 }
 
-func Test_AddCommand_AddToExistingWithComplexStdoutStructure(t *testing.T) {
+func Test_AddCommand_AddToExistingWithComplexStdStreamAssertions(t *testing.T) {
 	existing := []byte(`
 tests:
   exists:
@@ -35,6 +35,13 @@ tests:
         - exists
       not-contains:
         - byebye
+    stderr:
+      not-contains:
+        - stderr not
+      line-count: 10
+      lines:
+        1: line1
+        2: line2
     exit-code: 0
 `)
 
@@ -52,6 +59,13 @@ tests:
       - exists
       not-contains:
       - byebye
+    stderr:
+      lines:
+        1: line1
+        2: line2
+      line-count: 10
+      not-contains:
+      - stderr not
 `)
 
 	assert.Nil(t, err)

--- a/pkg/app/add_command_test.go
+++ b/pkg/app/add_command_test.go
@@ -24,3 +24,36 @@ tests:
 	assert.Nil(t, err)
 	assert.Equal(t, "tests:\n  echo exists:\n    exit-code: 0\n  echo hello:\n    exit-code: 0\n    stdout: hello\n", string(content))
 }
+
+func Test_AddCommand_AddToExistingWithComplexStdoutStructure(t *testing.T) {
+	existing := []byte(`
+tests:
+  exists:
+    command: echo exists
+    stdout:
+      contains:
+        - exists
+      not-contains:
+        - byebye
+    exit-code: 0
+`)
+
+	content, err := AddCommand("echo hello", existing)
+
+	expected := []byte(`tests:
+  echo hello:
+    exit-code: 0
+    stdout: hello
+  exists:
+    command: echo exists
+    exit-code: 0
+    stdout:
+      contains:
+      - exists
+      not-contains:
+      - byebye
+`)
+
+	assert.Nil(t, err)
+	assert.Equal(t, string(expected), string(content))
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -70,11 +70,11 @@ type Expected struct {
 
 //ExpectedOut represents the assertions on stdout and stderr
 type ExpectedOut struct {
-	Contains    []string
-	Lines       map[int]string
-	Exactly     string
-	LineCount   int
-	NotContains []string
+	Contains    []string       `yaml:"contains,omitempty"`
+	Lines       map[int]string `yaml:"lines,omitempty"`
+	Exactly     string         `yaml:"exactly,omitempty"`
+	LineCount   int            `yaml:"line-count,omitempty"`
+	NotContains []string       `yaml:"not-contains,omitempty"`
 }
 
 // CommandUnderTest represents the command under test


### PR DESCRIPTION
Fixes #86

## Checklist

 - [x] Added unit / integration tests for windows, macOS and Linux? 
 - [x] Added a changelog entry in [CHANGELOG.md](../CHANGELOG.md)?
 - [x] Updated the documentation ([README.md](../README.md), [docs](../docs))?
 - [x] Does your change work on `Linux`, `Windows` and `macOS`?