### PR TITLE
Add exe suffix to windows binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ dist: trusty
 
 before_install:
   - go get -u golang.org/x/lint/golint
-  - make deps
   - curl -L https://github.com/SimonBaeumer/commander/releases/download/v1.2.1/commander-linux-amd64 -o ~/bin/commander
   - chmod +x ~/bin/commander
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ stages:
   - deploy
 
 go:
-  - 1.12.x
+  - 1.13.x
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ dist: trusty
 before_install:
   - go get -u golang.org/x/lint/golint
   - make deps
-  - curl -L https://github.com/SimonBaeumer/commander/releases/download/v0.3.0/commander-linux-amd64 -o ~/bin/commander
+  - curl -L https://github.com/SimonBaeumer/commander/releases/download/v1.2.1/commander-linux-amd64 -o ~/bin/commander
   - chmod +x ~/bin/commander
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
     before_install:
       - choco install make
       - choco install curl
-      - curl -L https://github.com/SimonBaeumer/commander/releases/download/v0.3.0/commander-windows-amd64 -o C:\Windows\system32\commander.exe
+      - curl -L https://github.com/SimonBaeumer/commander/releases/download/v1.2.1/commander-windows-amd64 -o C:\Windows\system32\commander.exe
     script:
       - make integration-windows
 
@@ -83,8 +83,8 @@ jobs:
         - release/commander-linux-386
         - release/commander-darwin-amd64
         - release/commander-darwin-386
-        - release/commander-windows-amd64
-        - release/commander-windows-386
+        - release/commander-windows-amd64.exe
+        - release/commander-windows-386.exe
       skip_cleanup: true
       on:
         repo: SimonBaeumer/commander

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.2.2
+
+ - Rename windows binary `commander-windows-386` to `commander-windows-386.exe`
+ - Rename windows binary `commander-windows-amd64` to `commander-windows-amd64.exe`
+ - Use commander v1.2.1 in travis build
+
 # v1.2.1
 
  - Fix `add` command if `stdout` or `stderr` properties were removed if a new test was added

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ release-darwin-386:
 
 release-windows-amd64:
 	$(info INFO: Starting build $@)
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-windows-amd64 $(exe)
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-windows-amd64.exe $(exe)
 
 release-windows-386:
 	$(info INFO: Starting build $@)
-	CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-windows-386 $(exe)
+	CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags "-X main.version=$(TRAVIS_TAG) -s -w" -o release/$(cmd)-windows-386.exe $(exe)
 
 
 release: release-amd64 release-arm release-386 release-darwin-amd64 release-darwin-386 release-windows-amd64 release-windows-386


### PR DESCRIPTION
Fixes #99

## Checklist

 - [x] Added unit / integration tests for windows, macOS and Linux? 
 - [x] Added a changelog entry in [CHANGELOG.md](../CHANGELOG.md)?
 - [x] Updated the documentation ([README.md](../README.md), [docs](../docs))?
 - [x] Does your change work on `Linux`, `Windows` and `macOS`?