### PR TITLE
Add docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+A little check list for contributions:
+
+ - Create an issue if you want to add a bigger feature and lets talk about it
+ - Take a look at the documentation [development.md](docs/development.md)
+ - Take a look at the [pull request template](.github/PULL_REQUEST_TEMPLATE.md)
+ - If you need help don't hesitate to ask questions in pull requests or issues
+ - Issues you can work on are marked as "Help wantend", to be sure clarify the requirements of an issue in the comments
+ 
+Even if your code is not perfect I would also love to see pull requests or issues with your
+custom fork and implementations.
+
+Happy coding!

--- a/README.md
+++ b/README.md
@@ -738,49 +738,7 @@ tests:
 
 ### Development
 
-```
-# Initialise dev environment
-$ make init
-
-# Build the project binary
-$ make build
-
-# Unit tests
-$ make test
-
-# Coverage
-$ make test-coverage
-
-# Coverage with more complex tests like ssh execution
-$ make test-coverage-all
-
-# Integration tests for linux and macos
-$ make integration-unix
-
-# Integration on linux
-$ make integration-linux
-
-# Integration windows
-$ make integration-windows
-
-# Add depdencies to vendor
-$ make deps
-```
-
-### Unit tests
-
-`COMMANDER_TEST_ALL` will enable all tests which are depending on external systems like docker or databases.
-Enables ssh tests in unit test suite and sets the credentials for the target host.
-`COMMANDER_SSH_TEST` must be set to `1` to enable ssh tests.
-
-```
-export COMMANDER_TEST_ALL = 1
-export COMMANDER_TEST_SSH=1
-export COMMANDER_TEST_SSH_HOST=localhost:2222
-export COMMANDER_TEST_SSH_PASS=pass
-export COMMANDER_TEST_SSH_USER=root
-export COMMANDER_TEST_SSH_IDENTITY_FILE=integration/containers/ssh/.ssh/id_rsa
-```
+See the documentation at [development.md](docs/development.md)
 
 ## Misc
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,260 @@
 # Development documentation
 
-## Writing integration tests
+- [Introduction](#introduction)
+  * [Directory overview](#directory-overview)
+  * [Package overview](#package-overview)
+  * [Build targets](#build-targets)
+  * [Unit tests](#unit-tests)
+- [Extending commander](#extending-commander)
+  * [Add a new field to the `YAML` suite - with a leaning-by-doing task](#add-a-new-field-to-the--yaml--suite)
+  * [Writing integration tests](#writing-integration-tests)
+
+
+## Introduction
+
+### Directory overview
+
+```
+├── cmd          # Contains the composition root and files which will be compiled to binaries.
+├── docs         # Documentation for commander
+├── examples     # Examples of how to use commander with to give you a little bit inspiration.
+├── hack         # Just a directory for testing stuff and shitty dev scripts.
+├── integration  # Integration tests for all platforms, all written as test suites for commander.
+├── pkg          # All packages written in GoLang which are used to compose this tool.
+├── release      # All binaries which are created on `make release` are located here. Directory is in `.gitignore`.
+└── vendor       # Third party dependencies added by `go mod`.
+```
+
+### Package overview
+
+| **package** | **description**                                                                                                                                                                                                                                                                                                 | **path**       |
+|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|
+| main        | The composition root of the commander, initializes the `urfave/cli` framework.                                                                                                                                                                                                                                  | /cmd/commander |
+| app         | Contains all commands for commander, i.e. add or test. Will only be used by the `cmd` package located under `/cmd`                                                                                                                                                                                              | /pkg/app       |
+| matcher     | Implements the matching logic for the different assertions types in the suite like `equals, `contains`, `json` or `xml`.                                                                                                                                                                                        | /pkg/matcher   |
+| output      | Output is a package which allows to add different output types. For example it could be possible to add a new output format in `json` or for a health check.                                                                                                                                                    | /pkg/output    |
+| runtime     | Runtime controls the execution of the test suite. It will be initialized by the `main` package and will be a given a `Suite` which contains all tests to be executed. The runtime also contains all `executors` which are different types of ways to execute a test, i.e. on a local machine or a node viá ssh. | /pkg/runtime   |
+| suite       | Suite is responsible for parsing the defined formats of different test suites. At the moment only `yaml` is supported but it would be possible to add support for a custom DSL or formats like `toml` and `json`. The `suite.Suite` struct will be used by the `runtime.Runtime` for executing the tests.       | /pkg/suite     |
+
+
+### Build targets
+
+```
+# Initialise dev environment
+$ make init
+
+# Build the project binary
+$ make build
+
+# Unit tests
+$ make test
+
+# Coverage
+$ make test-coverage
+
+# Coverage with more complex tests like ssh execution
+$ make test-coverage-all
+
+# Integration tests for linux and macos
+$ make integration-unix
+
+# Integration on linux
+$ make integration-linux
+
+# Integration windows
+$ make integration-windows
+
+# Add depdencies to vendor
+$ make deps
+```
+
+### Unit tests
+
+`COMMANDER_TEST_ALL` will enable all tests which are depending on external systems like docker or databases.
+Enables ssh tests in unit test suite and sets the credentials for the target host.
+`COMMANDER_SSH_TEST` must be set to `1` to enable ssh tests.
+
+**Note:** I am aware that unit tests should not test external systems nor libraries, but in favour of simplicity and laziness
+I created simple tests inside the directory tree.
+
+```bash
+export COMMANDER_TEST_ALL=1
+export COMMANDER_TEST_SSH=1
+export COMMANDER_TEST_SSH_HOST=localhost:2222
+export COMMANDER_TEST_SSH_PASS=pass
+export COMMANDER_TEST_SSH_USER=root
+export COMMANDER_TEST_SSH_IDENTITY_FILE=integration/containers/ssh/.ssh/id_rsa
+```
+
+## Extending commander
+
+### Add a new field to the `YAML` suite - with a leaning-by-doing task
+
+It is a little bit annoying to add fields because it will be converted multiple times to keep the
+suite format abstracted from the runtime package. 
+The idea behind this it to add support for other formats like `json`, `toml` or maybe a custom DSL.
+
+**Definition of done**:
+
+ - Add a property `message` which always display a message while executing a test
+   ```yaml
+   tests:
+     echo hello:
+       exit-code: 0
+       config:
+         message: this is a very special test
+   ``` 
+ - Support global configurations
+ - Create a simple test case
+
+ **1. Extend the conversion struct `suite.YAMLTestConfigConf` in [yaml_suite.go](../pkg/suite/yaml_suite.go) with the `Message` property.**
+ 
+   The structs types with a `Conf` suffix represent the configuration type, the `YAML` prefix the format of the suite.
+   The naming makes it a little bit clearer in the code which type is used, i.e. a `runtime.CommandUnderTest` or a `suite.YAMLTestConfigConf`.
+    
+    ```go
+    Message    string            `yaml:"message,omitempty"`
+    ```
+    
+**2. Add the `Message` property as a `string` to the `runtime.CommandUnderTest` struct**
+ 
+   The `runtime.CommandUnderTest` struct in [runtime.go](../pkg/runtime/runtime.go) will be used by the runtime to 
+   create the command with all its configs like `env` variables and is used for the test execution.
+    
+**3. Add a simple test case**
+ 
+  Open [yaml_suite_test.go](../pkg/suite/yaml_suite_test.go) and look for an existing test to add this property or create a new one. 
+  I recommend to create a simple test case before adding the properties because it is easier to debug and test. 
+  In our example we could extend the `TestYAMLSuite_ShouldPreferLocalTestConfigs` test but will add a new `TestYAMLSuite_Message` test for the simplicity.
+  
+  ```go
+  func TestYamlSuite_Message(t *testing.T) {
+  yaml := []byte(`
+    tests:
+      echo hello:
+        exit-code: 0
+        config:
+          message: "This is a very special test"
+  `)
+    
+   got := ParseYAML(yaml)
+    
+    assert.Equal(t, "This is a very special test", got.TestCases[0].Command.Message)
+  }
+  ```
+    
+  Run the unit tests with `make test`. It should print a result like this:
+  
+  ```
+  --- FAIL: TestYamlSuite_Message (0.00s)
+      yaml_suite_test.go:192: 
+                  Error Trace:    yaml_suite_test.go:192
+                  Error:          Not equal: 
+                                  expected: "This is a very special test"
+                                  actual  : ""
+                                  
+                                  Diff:
+                                  --- Expected
+                                  +++ Actual
+                                  @@ -1 +1 @@
+                                  -This is a very special test
+                                  +
+                  Test:           TestYamlSuite_Message
+  FAIL
+  ```
+    
+**4. Parse YAML and convert it to `suite.Suite`**
+ 
+  This is a little bit complicated and error prone because it is splitted into three steps:
+  
+  - Parse YAML file
+  - Convert YAML config structs to runtime test structs
+  - Assign global configuration
+  
+  For this take a look at the `pkg/suite/yaml_suite.go:ParseYAML` function which is responsible for parsing the suite.
+  
+  1. Parse yaml - `err := yaml.UnmarshalStrict(content, &yamlConfig)`
+      This line parses the yaml file and will return a `suite.YAMLSuiteConf`, later it will be converted to our structs
+      from the `runtime` package.
+      Now we can implement our custom unmarshal logic in the `YAMLSuiteConf::UnmarshalYAML` method.
+      Follow the code where `Config:   y.mergeConfigs(v.Config, params.Config)` is called. 
+      This merges the local with global configs and overwrites the global if it is necessary.
+      
+      Jump into the `YAMLSuiteConf::mergeConfigs` and add the `message` property like this:
+      
+      ```go
+      if local.Message != "" {
+          conf.Message = local.Message
+      }
+
+      ```
+
+  1. Convert test cases - `tests := convertYAMLSuiteConfToTestCases(yamlConfig)`
+  
+     Jump into the `convertYAMLSuiteConfToTestCases` function and assign the content of our new field to the `runtime.CommandUnderTest` conversion.
+     
+     ```
+      Command: runtime.CommandUnderTest{
+          Cmd:        t.Command,
+          InheritEnv: t.Config.InheritEnv,
+          [...]
+          Message:    t.Config.Message,
+      },
+      ```
+      
+**5. Add the global config assignment and add the `Message` property**
+
+  Add a new `Message` property to the `runtime.GlobalTestConfig`.
+  
+  ```go
+  type GlobalTestConfig struct {
+  	Env        map[string]string
+  	[...]
+  	Message    string
+  }
+  ```
+  
+  And last but not least implement the assignment of the global config. 
+  This can be done easily inside the `return` of the `ParseYAML` function statement.
+
+   ```go       
+  	return Suite{
+  		TestCases: tests,
+  		Config: runtime.TestConfig{
+  			InheritEnv: yamlConfig.Config.InheritEnv,
+  			Env:        yamlConfig.Config.Env,
+  			Dir:        yamlConfig.Config.Dir,
+  			Timeout:    yamlConfig.Config.Timeout,
+  			Retries:    yamlConfig.Config.Retries,
+  			Interval:   yamlConfig.Config.Interval,
+  			Nodes:      yamlConfig.Config.Nodes,
+  		},
+  		Nodes: convertNodes(yamlConfig.Nodes),
+  	}
+   ```
+  
+**6. Run the tests**
+
+  ```bash
+  $ make test
+  INFO: Starting build test
+  go test ./...
+  ok      github.com/SimonBaeumer/commander/cmd/commander 0.011s
+  ok      github.com/SimonBaeumer/commander/pkg/app       0.014s
+  ok      github.com/SimonBaeumer/commander/pkg/matcher   (cached)
+  ok      github.com/SimonBaeumer/commander/pkg/output    (cached)
+  ok      github.com/SimonBaeumer/commander/pkg/runtime   0.229s
+  ok      github.com/SimonBaeumer/commander/pkg/suite     0.008s
+  ```
+     
+**7. Learning by doing**
+
+  Two tasks are missing which you can complete on your own.
+  
+   - Add the printing of the message (tip: Take a look into the `runtime.go` file)
+   - Extend the test case that it is tested that local configs are preferred over global configs (tip: Take a look at the other tests). 
+  
+### Writing integration tests
 
 Commander tests itself. You can find the integration tests in `commander_unix.yaml` and `commander_windows.yaml`.
 More complex scenarios are stored in `integration/`.
@@ -11,3 +265,4 @@ It is always necessary to execute the test suite with a stable version of comman
 
  - The working directory is by default the project root, even for tests located inside `integration/*`
  - Execute `commander` inside the `commander_*.yaml` files with a given suite and assert the result which is returned
+ 

--- a/pkg/app/add_command.go
+++ b/pkg/app/add_command.go
@@ -12,9 +12,9 @@ import (
 // command is the command which should be added to the test suite
 // existed holds the existing yaml content
 func AddCommand(command string, existed []byte) ([]byte, error) {
-	conf := suite.YAMLConfig{
+	conf := suite.YAMLSuiteConf{
 		Tests:  make(map[string]suite.YAMLTest),
-		Config: suite.YAMLTestConfig{},
+		Config: suite.YAMLTestConfigConf{},
 	}
 	c := cmd.NewCommand(command)
 
@@ -64,9 +64,9 @@ func AddCommand(command string, existed []byte) ([]byte, error) {
 	return out, nil
 }
 
-func convertConfig(config suite.YAMLTestConfig) suite.YAMLTestConfig {
+func convertConfig(config suite.YAMLTestConfigConf) suite.YAMLTestConfigConf {
 	if config.Dir == "" && len(config.Env) == 0 && config.Timeout == "" {
-		return suite.YAMLTestConfig{}
+		return suite.YAMLTestConfigConf{}
 	}
 	return config
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -70,8 +70,8 @@ type Node struct {
 	Privileged   bool
 }
 
-//TestConfig represents the configuration for a test
-type TestConfig struct {
+//GlobalTestConfig represents the configuration for a test
+type GlobalTestConfig struct {
 	Env        map[string]string
 	Dir        string
 	Timeout    string

--- a/pkg/suite/suite.go
+++ b/pkg/suite/suite.go
@@ -10,7 +10,7 @@ import (
 // In example it could be possible to add more formats like XML or a custom DSL implementation.
 type Suite struct {
 	TestCases []runtime.TestCase
-	Config    runtime.TestConfig
+	Config    runtime.GlobalTestConfig
 	Nodes     []runtime.Node
 }
 
@@ -54,6 +54,6 @@ func (s Suite) GetTestByTitle(title string) (runtime.TestCase, error) {
 }
 
 // GetGlobalConfig returns the global configuration which applies to the complete suite
-func (s Suite) GetGlobalConfig() runtime.TestConfig {
+func (s Suite) GetGlobalConfig() runtime.GlobalTestConfig {
 	return s.Config
 }

--- a/pkg/suite/suite_test.go
+++ b/pkg/suite/suite_test.go
@@ -43,6 +43,6 @@ func Test_GetTestByTitle(t *testing.T) {
 }
 
 func Test_GetGlobalConfig(t *testing.T) {
-	s := Suite{Config: runtime.TestConfig{Dir: "/tmp"}}
+	s := Suite{Config: runtime.GlobalTestConfig{Dir: "/tmp"}}
 	assert.Equal(t, "/tmp", s.GetGlobalConfig().Dir)
 }

--- a/pkg/suite/yaml_suite_test.go
+++ b/pkg/suite/yaml_suite_test.go
@@ -113,7 +113,7 @@ tests:
 func Test_YAMLConfig_convertToExpectedOut(t *testing.T) {
 	in := map[interface{}]interface{}{"exactly": "exactly stderr"}
 
-	y := YAMLConfig{}
+	y := YAMLSuiteConf{}
 	got := y.convertToExpectedOut(in)
 
 	assert.IsType(t, runtime.ExpectedOut{}, got)
@@ -203,6 +203,8 @@ tests:
 `)
 
 	got := ParseYAML(yaml)
+
+	// Assert global variables
 	assert.Equal(t, map[string]string{"KEY": "global", "ANOTHER_KEY": "another_global"}, got.GetGlobalConfig().Env)
 	assert.Equal(t, "/home/commander/", got.GetGlobalConfig().Dir)
 	assert.Equal(t, "10ms", got.GetGlobalConfig().Timeout)
@@ -210,6 +212,7 @@ tests:
 	assert.Equal(t, "500ms", got.GetGlobalConfig().Interval)
 	assert.True(t, got.GetGlobalConfig().InheritEnv)
 
+	// Assert local variables
 	assert.Equal(t, map[string]string{"KEY": "local", "ANOTHER_KEY": "another_global"}, got.GetTests()[0].Command.Env)
 	assert.Equal(t, "/home/test", got.GetTests()[0].Command.Dir)
 	assert.Equal(t, "1s", got.GetTests()[0].Command.Timeout)
@@ -256,7 +259,7 @@ tests:
 }
 
 func Test_YAMLConfig_MarshalYAML(t *testing.T) {
-	conf := YAMLConfig{Tests: map[string]YAMLTest{
+	conf := YAMLSuiteConf{Tests: map[string]YAMLTest{
 		"return_string": {
 			Stdout: runtime.ExpectedOut{Contains: []string{"stdout string"}},
 			Stderr: runtime.ExpectedOut{Contains: []string{"stderr string"}},
@@ -278,7 +281,7 @@ func Test_YAMLConfig_MarshalYAML(t *testing.T) {
 	}}
 
 	out, _ := conf.MarshalYAML()
-	r := out.(YAMLConfig)
+	r := out.(YAMLSuiteConf)
 
 	assert.Equal(t, "stdout string", r.Tests["return_string"].Stdout)
 	assert.Equal(t, "stderr string", r.Tests["return_string"].Stderr)


### PR DESCRIPTION
Fixes #116 

 - Add a tutorial for adding new fields to the yaml suite
 - Create an introduction to the package and directory structure
 - Renaming of confusing structs 
 - Add CONTIRBUTING.md

I appreciate feedback, especially related to my grammar and if it is possible to follow along the topic :D

The doc can be found [here](https://github.com/SimonBaeumer/commander/blob/add-docs/docs/development.md).

The implementation of the `Message` property can be viewed in commit [8e269a](https://github.com/SimonBaeumer/commander/pull/117/commits/8e269aefabac980a78d6a7cf4a0ba015fcb8851d).

**ToDo:**

 - [x] Squash commits