### PR TITLE
set alpine version to 3.11.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
 
   - name: Integration test
     script:
-      - docker pull docker.io/library/alpine:3.11
+      - docker pull docker.io/library/alpine:3.11.3
       - make integration-linux
 
   - stage: deploy

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ The `docker` node type executes the given command inside a docker container.
 nodes:
   docker-host:
     type: docker
-    image: docker.io/library/alpine:3.11
+    image: docker.io/library/alpine:3.11.3
     user: 1000 # define the owner of the executed command
 config:
   nodes:

--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 )
+
+go 1.13

--- a/integration/linux/docker.yaml
+++ b/integration/linux/docker.yaml
@@ -1,7 +1,7 @@
 nodes:
   docker-host:
     type: docker
-    image: docker.io/library/alpine:3.11
+    image: docker.io/library/alpine:3.11.3
     user: 1001
 
 config:


### PR DESCRIPTION
Fixes #
- changed `travis.yml` to specify alpine version
- changed `integration/linux/docker.yaml` to specify alpine version

## Checklist

 - [ ] Added unit / integration tests for windows, macOS and Linux? 
 - [ ] Added a changelog entry in [CHANGELOG.md](../CHANGELOG.md)? Should I do this?
 - [x] Updated the documentation ([README.md](../README.md), [docs](../docs))?
 - [x] Does your change work on `Linux`, `Windows` and `macOS`?