### PR TITLE
edit readme and helper message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.1.1
+
+ - Add limitations of `--dir` to helper message
+
 # v2.1.0
 
  - Add registry authentication for `docker` nodes

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ $ ./commander test /tmp/test.yaml
 # Execute a single test
 $ ./commander test /tmp/test.yaml "my test"
 
-# Execute suites within a test directory
+# Execute suites within a test directory, 
+# directory can only contain subdirs and valid test files
 $ ./commander test --dir /tmp
 ```
 

--- a/cmd/commander/commander.go
+++ b/cmd/commander/commander.go
@@ -60,8 +60,9 @@ func createTestCommand() cli.Command {
 				EnvVar: "COMMANDER_VERBOSE",
 			},
 			cli.BoolFlag{
-				Name:  "dir",
-				Usage: "Execute all test files in a directory sorted by file name, this is not recursive - e.g. /path/to/test_files/",
+				Name: "dir",
+				Usage: `Execute all test files in a directory sorted by file name, this is not recursive - e.g. /path/to/test_files/
+	The directory can only contain subdirs and valid test files`,
 			},
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
Closes #129 

Adds documentation for the limitations of the `--dir` feature. These limitation will be addressed #131.

## Checklist

 - [ ] Added unit / integration tests for windows, macOS and Linux? 
 - [x] Added a changelog entry in [CHANGELOG.md](../CHANGELOG.md)?
 - [X] Updated the documentation ([README.md](../README.md), [docs](../docs))?
 - [ ] Does your change work on `Linux`, `Windows` and `macOS`?